### PR TITLE
Update copyright year in license and readme files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ npm test
 
 # License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/adapter-commons/LICENSE
+++ b/packages/adapter-commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-commons/README.md
+++ b/packages/adapter-commons/README.md
@@ -22,6 +22,6 @@ Refer to the [Feathers database adapter documentation](https://feathersjs.com/ap
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/adapter-tests/LICENSE
+++ b/packages/adapter-tests/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -16,6 +16,6 @@ This is a repository that contains the test suite for the common database adapte
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/authentication-client/LICENSE
+++ b/packages/authentication-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-client/README.md
+++ b/packages/authentication-client/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers authentication client API documentation](https://feathers
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/authentication-local/LICENSE
+++ b/packages/authentication-local/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-local/README.md
+++ b/packages/authentication-local/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers local authentication API documentation](https://feathersj
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/authentication-oauth/LICENSE
+++ b/packages/authentication-oauth/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication-oauth/README.md
+++ b/packages/authentication-oauth/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers oAuth authentication API documentation](https://feathersj
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/authentication/LICENSE
+++ b/packages/authentication/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/authentication/README.md
+++ b/packages/authentication/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers authentication API documentation](https://feathersjs.com/
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,6 @@ Refer to the [Feathers CLI guide](https://feathersjs.com/guides/cli/) for more d
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers client API documentation](https://docs.feathersjs.com/api
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/commons/LICENSE
+++ b/packages/commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/commons/README.md
+++ b/packages/commons/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers API](https://feathersjs.com/api) for more details.
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/configuration/LICENSE
+++ b/packages/configuration/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/configuration/README.md
+++ b/packages/configuration/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers configuration API documentation](https://feathersjs.com/a
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/create-feathers/README.md
+++ b/packages/create-feathers/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers guides](https://feathersjs.com/guides/) for more details.
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/errors/LICENSE
+++ b/packages/errors/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers errors API documentation](https://feathersjs.com/api/erro
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/express/LICENSE
+++ b/packages/express/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers Express API documentation](https://feathersjs.com/api/exp
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/feathers/LICENSE
+++ b/packages/feathers/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/feathers/README.md
+++ b/packages/feathers/README.md
@@ -28,6 +28,6 @@ To learn more about Feathers visit the website at [feathersjs.com](http://feathe
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/generators/README.md
+++ b/packages/generators/README.md
@@ -17,6 +17,6 @@ Refer to the [Feathers CLI guide](https://feathersjs.com/guides/cli/) for more d
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/knex/LICENSE
+++ b/packages/knex/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/knex/README.md
+++ b/packages/knex/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers Knex adapter documentation](https://feathersjs.com/api/da
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/koa/README.md
+++ b/packages/koa/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers Koa API documentation](https://feathersjs.com/api/koa.htm
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/memory/LICENSE
+++ b/packages/memory/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -18,6 +18,6 @@ See [FeathersJS Memory Adapter API documentation](https://feathersjs.com/api/dat
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/mongodb/LICENSE
+++ b/packages/mongodb/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers MongoDB adapter documentation](https://feathersjs.com/api
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/rest-client/LICENSE
+++ b/packages/rest-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/rest-client/README.md
+++ b/packages/rest-client/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers REST client API documentation](https://feathersjs.com/api
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/schema/LICENSE
+++ b/packages/schema/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers schema API documentation](https://feathersjs.com/api/sche
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/socketio-client/LICENSE
+++ b/packages/socketio-client/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/socketio-client/README.md
+++ b/packages/socketio-client/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers SocketIO API documentation](https://feathersjs.com/api/cl
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/socketio/LICENSE
+++ b/packages/socketio/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/socketio/README.md
+++ b/packages/socketio/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers SocketIO API documentation](https://feathersjs.com/api/so
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/tests/LICENSE
+++ b/packages/tests/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/transport-commons/LICENSE
+++ b/packages/transport-commons/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/transport-commons/README.md
+++ b/packages/transport-commons/README.md
@@ -8,6 +8,6 @@
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).

--- a/packages/typebox/LICENSE
+++ b/packages/typebox/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Feathers Contributors
+Copyright (c) 2024 Feathers Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/typebox/README.md
+++ b/packages/typebox/README.md
@@ -18,6 +18,6 @@ Refer to the [Feathers TypeBox documentation](https://feathersjs.com/api/schema/
 
 ## License
 
-Copyright (c) 2023 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
+Copyright (c) 2024 [Feathers contributors](https://github.com/feathersjs/feathers/graphs/contributors)
 
 Licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.
  This PR updates the copyright year from 2023 to 2024 in all `LICENSE` and `README.md` files across the project to reflect the current year.
- [ ] Are there any open issues that are related to this?
  N/A
- [ ] Is this PR dependent on PRs in other repos?
  N/A

### Other Information

N/A

Thanks for contributing to Feathers! :heart:

---
<a href="https://cursor.com/background-agent?bcId=bc-be8da87e-ad65-44bd-803f-a6a6867ea032">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be8da87e-ad65-44bd-803f-a6a6867ea032">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

